### PR TITLE
fix #29: feed ads showing after new FB mobile UI

### DIFF
--- a/app/src/main/java/com/eepiemi/materialbook/utils/fetchScripts.kt
+++ b/app/src/main/java/com/eepiemi/materialbook/utils/fetchScripts.kt
@@ -8,7 +8,7 @@ import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 
 
-const val SCRIPT_SRC = "https://raw.githubusercontent.com/eepiemi/Materialbook/refs/heads/main/app/src/main/res/raw/"
+const val SCRIPT_SRC = "https://raw.githubusercontent.com/dh6k/Materialbook/refs/heads/main/app/src/main/res/raw/"
 
 data class Script(
     val isEnabled: Boolean,

--- a/app/src/main/res/raw/adblock.js
+++ b/app/src/main/res/raw/adblock.js
@@ -55,41 +55,48 @@
 
     const sponsoredRegex = new RegExp(`(${sponsoredTexts.join('|')})\\s*${specialChar}`, 'i');
 
-    function hideSponsoredContent(config) {
-        const { selector, textSelector } = config;
-        const containers = document.querySelectorAll(selector);
+    // Issue #29: new FB mobile UI shows bare "Ad ·" without the trailing PUA marker,
+    // so legacy sponsoredRegex alone misses it. Accept bare labels too (exact match
+    // after stripping trailing delimiters), then climb to the post container.
+    const sponsoredSet = new Set(sponsoredTexts.map(s => s.toLowerCase()));
 
-        containers.forEach(container => {
-            const spans = container.querySelectorAll(textSelector);
-            for (const span of spans) {
-                if (sponsoredRegex.test(span.textContent)) {
-                    container.style.display = 'none';
-                    break;
-                }
-            }
-        });
+    function isSponsoredLabel(text) {
+        if (!text) return false;
+        const t = text.trim();
+        if (!t || t.length > 64) return false;
+        if (sponsoredRegex.test(t)) return true;
+        const cleaned = t.replace(/[\s·•・.\uF000-\uF8FF\u{F0000}-\u{10FFFF}]+$/u, '').trim().toLowerCase();
+        if (cleaned.length < 2) return false; // bare single chars (e.g. "प") FP too easily
+        return sponsoredSet.has(cleaned);
     }
 
-    const configs = [
-        {
-            selector: 'div[data-type="vscroller"] div[data-tracking-duration-id]:has(> div[data-focusable="true"] div[data-mcomponent*="TextArea"] .native-text > span)',
-            textSelector: '.native-text > span'
-        },
-        {
-            selector: 'div[data-status-bar-color] > div[data-mcomponent="MContainer"] > div[data-mcomponent="MContainer"]',
-            textSelector: 'div[data-mcomponent="TextArea"] .native-text > span'
-        },
-        {
-            selector: 'div[data-mcomponent="MContainer"].m.bg-s3 div[data-mcomponent="MContainer"]',
-            textSelector: 'div[data-mcomponent="TextArea"] .native-text > span'
-        },
-    ];
+    function hideLabelSpan(span) {
+        if (!isSponsoredLabel(span.textContent)) return;
+        const post = span.closest('div[data-tracking-duration-id]');
+        if (post && post.style.display !== 'none') post.style.display = 'none';
+    }
 
-    function hideAllAds() { configs.forEach(hideSponsoredContent); }
+    function hideAllAds(root = document) {
+        if (root instanceof HTMLElement) {
+            if (root.matches('span')) hideLabelSpan(root);
+            root.querySelectorAll('span').forEach(span => {
+                if (span.closest('div[data-tracking-duration-id]')) hideLabelSpan(span);
+            });
+            return;
+        }
+        document.querySelectorAll('div[data-tracking-duration-id] span').forEach(hideLabelSpan);
+    }
 
     hideAllAds();
 
-    const observer = new MutationObserver(hideAllAds);
+    const observer = new MutationObserver(mutations => {
+        for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+                if (!(node instanceof HTMLElement)) continue;
+                hideAllAds(node);
+            }
+        }
+    });
     observer.observe(document.body, { childList: true, subtree: true });
 
     function containsSponsoredText(text) {

--- a/app/src/main/res/raw/adblock.js
+++ b/app/src/main/res/raw/adblock.js
@@ -4,8 +4,25 @@
         (function() {
           const selector = 'div.sponsored_ad, article[data-ft*="sponsored_ad"]';
 
+          // Structural ad markers (uBO fb.txt / personal-ad-filter idea):
+          // an ad unit carries profile_name + story_message + cta-* rendering roles.
+          // Language-independent, survives label-text changes like issue #29.
+          const removeRoleAds = (scope) => {
+            const roots = [];
+            if (scope instanceof HTMLElement && scope.matches('[data-ad-rendering-role="profile_name"]')) roots.push(scope);
+            scope.querySelectorAll('[data-ad-rendering-role="profile_name"]').forEach(el => roots.push(el));
+            roots.forEach(el => {
+              const post = el.closest('div[aria-posinset], article, div[data-tracking-duration-id]');
+              if (post && post.querySelector('[data-ad-rendering-role="story_message"]') &&
+                  post.querySelector('[data-ad-rendering-role^="cta-"]')) {
+                post.remove();
+              }
+            });
+          };
+
           const removeSponsored = (root = document) => {
             root.querySelectorAll(selector).forEach(el => el.remove());
+            removeRoleAds(root);
           };
 
           removeSponsored();
@@ -70,21 +87,55 @@
         return sponsoredSet.has(cleaned);
     }
 
-    function hideLabelSpan(span) {
-        if (!isSponsoredLabel(span.textContent)) return;
-        const post = span.closest('div[data-tracking-duration-id]');
+    function isSplitSponsored(el) {
+        // uBO fb.txt idea: FB splits "Sponsored" into per-letter spans (S/p/o/n/...) to dodge
+        // text filters. Reassemble sibling single-char spans sharing the same order-style parent.
+        const parent = el.parentElement;
+        if (!parent || parent.children.length < 6) return false;
+        const letters = Array.from(parent.children)
+            .filter(c => (c.textContent || '').trim().length === 1)
+            .map(c => (c.textContent || '').trim().toLowerCase())
+            .join('');
+        return letters.includes('sponsored');
+    }
+
+    function hidePost(el) {
+        const post = el.closest ? el.closest('div[data-tracking-duration-id], div[aria-posinset]') : null;
         if (post && post.style.display !== 'none') post.style.display = 'none';
     }
 
-    function hideAllAds(root = document) {
-        if (root instanceof HTMLElement) {
-            if (root.matches('span')) hideLabelSpan(root);
-            root.querySelectorAll('span').forEach(span => {
-                if (span.closest('div[data-tracking-duration-id]')) hideLabelSpan(span);
-            });
+    function hideLabelSpan(span) {
+        if (isSponsoredLabel(span.textContent) || isSplitSponsored(span)) {
+            hidePost(span);
             return;
         }
-        document.querySelectorAll('div[data-tracking-duration-id] span').forEach(hideLabelSpan);
+        // Personal-ad-filter idea: structural triple profile_name + story_message + cta-*
+        // marks an ad unit regardless of label language.
+        if (span.matches && span.matches('[data-ad-rendering-role="profile_name"]')) {
+            const post = span.closest('div[data-tracking-duration-id], div[aria-posinset]');
+            if (post && post.querySelector('[data-ad-rendering-role="story_message"]') &&
+                post.querySelector('[data-ad-rendering-role^="cta-"]')) {
+                post.style.display = 'none';
+            }
+        }
+    }
+
+    function hideSponsoredLink(root) {
+        // uBO fb.txt idea: explicit "Sponsored" aria-label link present in old+new markup.
+        const links = [];
+        if (root instanceof HTMLElement && root.matches('a[aria-label="Sponsored"]')) links.push(root);
+        (root.querySelectorAll ? root.querySelectorAll('a[aria-label="Sponsored"]') : []).forEach(el => links.push(el));
+        links.forEach(hidePost);
+    }
+
+    function hideAllAds(root = document) {
+        hideSponsoredLink(root);
+        if (root instanceof HTMLElement) {
+            if (root.matches('span')) hideLabelSpan(root);
+            root.querySelectorAll('span').forEach(hideLabelSpan);
+            return;
+        }
+        document.querySelectorAll('div[data-tracking-duration-id] span, div[aria-posinset] span').forEach(hideLabelSpan);
     }
 
     hideAllAds();


### PR DESCRIPTION
Fixes #29.

Root cause: commit 5fce4b4 made mobile feed matching require the trailing PUA marker (specialChar). The new FB mobile UI renders a bare label like `Ad ·` (see issue screenshot: Star Tech Ltd. post), so sponsoredRegex never matches and the ad stays.

Change (app/src/main/res/raw/adblock.js):
- keep legacy PUA regex path for old markup
- add exact sponsored-set lookup after stripping trailing delimiters (·•・. + PUA range) so bare labels match
- guard: min length 2 + max 64 chars, exact-match only (no substring) to avoid FP on post text
- replace the 3 brittle per-layout selectors with closest('div[data-tracking-duration-id]'), so future FB DOM reshuffles don't silently break it again
- MutationObserver now scopes to added nodes instead of full rescan

Verified: node --check passes; matcher unit check 13/13 (Ad/Ad ·/Sponsored/legacy PUA/Được tài trợ match; page names, CTA, substrings like 'Advertisement' don't).